### PR TITLE
Preidentification event, and storing the tier on the unidentified ite…

### DIFF
--- a/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/api/identification/PreIdentificationEvent.kt
+++ b/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/api/identification/PreIdentificationEvent.kt
@@ -9,13 +9,12 @@ import org.bukkit.inventory.ItemStack
 /**
  * Fired when a Player identifies an item. Can modify the result.
  */
-class PreIdentificationEvent(unidentifiedItem: ItemStack, tier: Tier, identifier: Player) : MythicDropsCancellableEvent() {
+class PreIdentificationEvent(unidentifiedItem: ItemStack, tier: Tier, val identifier: Player) : MythicDropsCancellableEvent() {
     companion object {
         @JvmStatic
         val handlerList = HandlerList()
     }
 
-    var identifier: Player = identifier
     var isModified: Boolean = false
         private set
     var tier: Tier = tier
@@ -23,8 +22,6 @@ class PreIdentificationEvent(unidentifiedItem: ItemStack, tier: Tier, identifier
             field = value
             isModified = true
         }
-    var unidentifiedItem: ItemStack = unidentifiedItem
-        private set
 
     override fun getHandlers(): HandlerList = handlerList
 }

--- a/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/api/identification/PreIdentificationEvent.kt
+++ b/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/api/identification/PreIdentificationEvent.kt
@@ -1,0 +1,30 @@
+package com.tealcube.minecraft.bukkit.mythicdrops.api.identification
+
+import com.tealcube.minecraft.bukkit.mythicdrops.api.events.MythicDropsCancellableEvent
+import com.tealcube.minecraft.bukkit.mythicdrops.api.tiers.Tier
+import org.bukkit.entity.Player
+import org.bukkit.event.HandlerList
+import org.bukkit.inventory.ItemStack
+
+/**
+ * Fired when a Player identifies an item. Can modify the result.
+ */
+class PreIdentificationEvent(unidentifiedItem: ItemStack, tier: Tier, identifier: Player) : MythicDropsCancellableEvent() {
+    companion object {
+        @JvmStatic
+        val handlerList = HandlerList()
+    }
+
+    var identifier: Player = identifier
+    var isModified: Boolean = false
+        private set
+    var tier: Tier = tier
+        set(value) {
+            field = value
+            isModified = true
+        }
+    var unidentifiedItem: ItemStack = unidentifiedItem
+        private set
+
+    override fun getHandlers(): HandlerList = handlerList
+}

--- a/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/identification/IdentificationInventoryDragListener.kt
+++ b/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/identification/IdentificationInventoryDragListener.kt
@@ -83,7 +83,7 @@ internal class IdentificationInventoryDragListener(
         // Get potential tier from last line of lore
         val targetItemLore = targetItem.lore
 
-        var tier: Tier? = attemptToGetTierForIdentify(targetItemLore, targetItem)
+        val tier: Tier? = attemptToGetTierForIdentify(targetItemLore, targetItem)
         if (tier == null) {
             Log.debug("tier == null")
             player.sendMythicMessage(
@@ -93,7 +93,7 @@ internal class IdentificationInventoryDragListener(
             return
         }
 
-        var preIdentificationEvent = PreIdentificationEvent(targetItem, tier, player)
+        val preIdentificationEvent = PreIdentificationEvent(targetItem, tier, player)
         Bukkit.getPluginManager().callEvent(preIdentificationEvent)
 
         if (preIdentificationEvent.isCancelled) {
@@ -104,14 +104,11 @@ internal class IdentificationInventoryDragListener(
             )
             return
         }
-        else if (preIdentificationEvent.isModified) {
-            tier = preIdentificationEvent.tier
-        }
 
         val newTargetItem = MythicDropsApi.mythicDrops.productionLine.tieredItemFactory.getNewDropBuilder()
             .withItemGenerationReason(ItemGenerationReason.DEFAULT)
             .withMaterial(targetItem.type)
-            .withTier(tier)
+            .withTier(preIdentificationEvent.tier)
             .useDurability(false)
             .build()
 

--- a/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/items/factories/MythicIdentificationItemFactory.kt
+++ b/src/main/kotlin/com/tealcube/minecraft/bukkit/mythicdrops/items/factories/MythicIdentificationItemFactory.kt
@@ -35,6 +35,8 @@ import io.pixeloutlaw.minecraft.spigot.mythicdrops.getApplicableTiers
 import io.pixeloutlaw.minecraft.spigot.mythicdrops.getMaterials
 import io.pixeloutlaw.minecraft.spigot.mythicdrops.isZero
 import io.pixeloutlaw.minecraft.spigot.mythicdrops.toTitleCase
+import io.pixeloutlaw.minecraft.spigot.mythicdrops.setPersistentDataString
+import io.pixeloutlaw.minecraft.spigot.mythicdrops.mythicDropsTier
 import org.bukkit.Material
 import org.bukkit.entity.EntityType
 import org.bukkit.inventory.ItemStack
@@ -88,6 +90,9 @@ class MythicIdentificationItemFactory(
             setDisplayNameChatColorized(settingsManager.identifyingSettings.items.unidentifiedItem.name)
             setLoreChatColorized(lore)
             setRepairCost(DEFAULT_REPAIR_COST)
+            tier?.let{
+                setPersistentDataString(mythicDropsTier, tier.name)
+            }
         }
     }
 


### PR DESCRIPTION
Allowing for defined tier on the unidentified item in persistent metadata instead of relying on lore for 1.16+